### PR TITLE
add the function to output dockerfile

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CommonGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CommonGenerateManager.java
@@ -63,6 +63,9 @@ public class CommonGenerateManager extends GenerateManager {
 		gr = generateComponentConf(contextMap);
 		result.add(gr);
 
+		gr = generateDockerfile(contextMap);
+		result.add(gr);
+
 		return result;
 	}
 
@@ -92,6 +95,15 @@ public class CommonGenerateManager extends GenerateManager {
 		RtcParam rtcParam = (RtcParam) contextMap.get("rtcParam");
 		String outfile = rtcParam.getName() + ".conf";
 		String infile = "common/Component.conf.vsl";
+		GeneratedResult result = generate(infile, outfile, contextMap);
+		result.setNotBom(true);
+		return result;
+	}
+
+	public GeneratedResult generateDockerfile(Map<String, Object> contextMap) {
+		RtcParam rtcParam = (RtcParam) contextMap.get("rtcParam");
+		String outfile = "Dockerfile." + rtcParam.getName();
+		String infile = "dockerfile/Dockerfile.vsl";
 		GeneratedResult result = generate(infile, outfile, contextMap);
 		result.setNotBom(true);
 		return result;

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/dockerfile/Dockerfile.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/dockerfile/Dockerfile.vsl
@@ -1,25 +1,25 @@
-ARG arch=amd64
-
-FROM ${arch}/alpine:3.10 as omniorb
+FROM alpine:3.10 as omniorb
 
 RUN apk add --no-cache\
  g++\
  make\
- python3-dev\
-    && ln -s /usr/bin/python3 /usr/bin/python
+ python3-dev
 
-RUN wget -O - 'https://sourceforge.net/projects/omniorb/files/omniORB/omniORB-4.2.3/omniORB-4.2.3.tar.bz2' | tar jxf -
+RUN wget -O - 'https://sourceforge.net/projects/omniorb/files/omniORB/omniORB-4.2.3/omniORB-4.2.3.tar.bz2'\
+ | tar jxf -
 WORKDIR /omniORB-4.2.3
-RUN ./configure --prefix=/opt/omniorb
+RUN PYTHON=/usr/bin/python3 ./configure\
+ --prefix=/opt/omniorb
 RUN make -j$(nproc)
 RUN make install
 WORKDIR /
 # replace paths to install /usr/local
-RUN find /opt/omniorb -type f | xargs sed -i -e 's@/opt/omniorb@/usr/local@g'
+RUN find /opt/omniorb -type f\
+ | xargs sed -i -e 's@/opt/omniorb@/usr/local@g'
 RUN strip /opt/omniorb/lib/lib*so
 
-${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}
-FROM ${arch}/alpine:3.10 as openrtm
+# --------------------------------------------------------------------------------
+FROM alpine:3.10 as openrtm
 
 # install omniORB
 COPY --from=omniorb /opt/omniorb /usr/local
@@ -30,18 +30,21 @@ RUN apk add --no-cache\
  cmake\
  util-linux-dev\
  python3-dev\
-    && ln -s /usr/bin/python3 /usr/bin/python
+ && ln -s /usr/bin/python3 /usr/bin/python
 # util-linux-dev for libuuid.so and uuid.h
 
-COPY OpenRTM-aist /OpenRTM-aist
-RUN cmake -G Ninja -S /OpenRTM-aist -B /tmp/build\
+
+RUN wget -O - 'https://github.com/OpenRTM/OpenRTM-aist/archive/master.zip'\
+ | unzip -
+
+RUN cmake -G Ninja -S /OpenRTM-aist-master -B /tmp/build\
  -DCMAKE_BUILD_TYPE=Release\
  -DCMAKE_INSTALL_LIBDIR=lib\
  -DCMAKE_INSTALL_PREFIX=/opt/openrtm
 RUN cmake --build /tmp/build -j --target install/strip
 
-${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}
-FROM ${arch}/alpine:3.10 as rtc
+# --------------------------------------------------------------------------------
+FROM alpine:3.10 as rtc
 
 # install omniORB
 COPY --from=omniorb /opt/omniorb /usr/local
@@ -56,17 +59,19 @@ RUN apk add --no-cache\
  libuuid\
  pkgconf
 
-COPY ${rtcParam.name} /RTC
+COPY / /RTC
 RUN cmake -G Ninja -S /RTC -B /tmp/build\
  -DCMAKE_BUILD_TYPE=Release\
  -DCMAKE_INSTALL_PREFIX=/opt/rtc
 RUN cmake --build /tmp/build -j --target install/strip
 
 RUN mkdir -p /opt/rtc_lib
-RUN cp -p $(ldd /opt/rtc/components/bin/${rtcParam.name}Comp | grep -e libomni -e libRTC | sed -e 's/.*=> //' | sed -e 's/(0x[0-9a-f]*)$//') /opt/rtc_lib
+RUN cp -p $(ldd /opt/rtc/components/bin/${rtcParam.name}Comp\
+ | grep -e libomni -e libRTC | sed -e 's/.*=> //'\
+ | sed -e 's/(0x[0-9a-f]*)$//') /opt/rtc_lib
 
-${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}
-FROM ${arch}/alpine:3.10
+# --------------------------------------------------------------------------------
+FROM alpine:3.10
 
 ARG username=noroot
 #if( ${rtcParam.docCreator.length()} > 0 )

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/dockerfile/Dockerfile.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/dockerfile/Dockerfile.vsl
@@ -1,0 +1,87 @@
+ARG arch=amd64
+
+FROM ${arch}/alpine:3.10 as omniorb
+
+RUN apk add --no-cache\
+ g++\
+ make\
+ python3-dev\
+    && ln -s /usr/bin/python3 /usr/bin/python
+
+RUN wget -O - 'https://sourceforge.net/projects/omniorb/files/omniORB/omniORB-4.2.3/omniORB-4.2.3.tar.bz2' | tar jxf -
+WORKDIR /omniORB-4.2.3
+RUN ./configure --prefix=/opt/omniorb
+RUN make -j$(nproc)
+RUN make install
+WORKDIR /
+# replace paths to install /usr/local
+RUN find /opt/omniorb -type f | xargs sed -i -e 's@/opt/omniorb@/usr/local@g'
+RUN strip /opt/omniorb/lib/lib*so
+
+${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}
+FROM ${arch}/alpine:3.10 as openrtm
+
+# install omniORB
+COPY --from=omniorb /opt/omniorb /usr/local
+
+RUN apk add --no-cache\
+ g++\
+ ninja\
+ cmake\
+ util-linux-dev\
+ python3-dev\
+    && ln -s /usr/bin/python3 /usr/bin/python
+# util-linux-dev for libuuid.so and uuid.h
+
+COPY OpenRTM-aist /OpenRTM-aist
+RUN cmake -G Ninja -S /OpenRTM-aist -B /tmp/build\
+ -DCMAKE_BUILD_TYPE=Release\
+ -DCMAKE_INSTALL_LIBDIR=lib\
+ -DCMAKE_INSTALL_PREFIX=/opt/openrtm
+RUN cmake --build /tmp/build -j --target install/strip
+
+${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}
+FROM ${arch}/alpine:3.10 as rtc
+
+# install omniORB
+COPY --from=omniorb /opt/omniorb /usr/local
+# install OpenRTM
+COPY --from=openrtm /opt/openrtm /opt/openrtm
+ENV LD_LIBRARY_PATH=/opt/openrtm/lib
+
+RUN apk add --no-cache\
+ g++\
+ ninja\
+ cmake\
+ libuuid\
+ pkgconf
+
+COPY ${rtcParam.name} /RTC
+RUN cmake -G Ninja -S /RTC -B /tmp/build\
+ -DCMAKE_BUILD_TYPE=Release\
+ -DCMAKE_INSTALL_PREFIX=/opt/rtc
+RUN cmake --build /tmp/build -j --target install/strip
+
+RUN mkdir -p /opt/rtc_lib
+RUN cp -p $(ldd /opt/rtc/components/bin/${rtcParam.name}Comp | grep -e libomni -e libRTC | sed -e 's/.*=> //' | sed -e 's/(0x[0-9a-f]*)$//') /opt/rtc_lib
+
+${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}${sharp}
+FROM ${arch}/alpine:3.10
+
+ARG username=noroot
+#if( ${rtcParam.docCreator.length()} > 0 )
+LABEL  maintainer="${tmpltHelper.convertAuthorDoc(${rtcParam.docCreator})}"
+#end
+
+RUN apk add --no-cache\
+ libstdc++\
+ libuuid\
+    && mkdir -m 777 /work\
+    && adduser -DH ${username}
+
+COPY --from=rtc /opt/rtc_lib /usr/local/lib
+COPY --from=rtc /opt/rtc/components/bin/${rtcParam.name}Comp /usr/local/components/bin/${rtcParam.name}Comp
+
+USER ${username}
+WORKDIR /work
+


### PR DESCRIPTION
## Identify the Bug
- 無し

## Description of the Change

- RTC Builder に実行環境を作成する Dockerfile を出力する機能を追加
- 出力されたDockerfile の使い方
  - docker build 時に1つの引数を指定できる、引数を指定しない場合はデフォルト値が使用される。
    - 実行コマンド例
      - docker build --build-arg username=hoge -f 出力されたDockerfile .

| 引数 | デフォルト値 | 用途 |
|:-----------|:------------|:------------|
| username  | noroot | コンテナを一般ユーザで起動する時に使う名前の指定   |

## Verification 
- [X] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  