### PR TITLE
add the function to output the manifest file for kubernetes

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CommonGenerateManager.java
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/manager/CommonGenerateManager.java
@@ -66,6 +66,9 @@ public class CommonGenerateManager extends GenerateManager {
 		gr = generateDockerfile(contextMap);
 		result.add(gr);
 
+		gr = generateDeployManifest(contextMap);
+		result.add(gr);
+
 		return result;
 	}
 
@@ -104,6 +107,15 @@ public class CommonGenerateManager extends GenerateManager {
 		RtcParam rtcParam = (RtcParam) contextMap.get("rtcParam");
 		String outfile = "Dockerfile." + rtcParam.getName();
 		String infile = "dockerfile/Dockerfile.vsl";
+		GeneratedResult result = generate(infile, outfile, contextMap);
+		result.setNotBom(true);
+		return result;
+	}
+
+	public GeneratedResult generateDeployManifest(Map<String, Object> contextMap) {
+		RtcParam rtcParam = (RtcParam) contextMap.get("rtcParam");
+		String outfile = rtcParam.getName() + ".yaml";
+		String infile = "kubernetes/DeployManifest.vsl";
 		GeneratedResult result = generate(infile, outfile, contextMap);
 		result.setNotBom(true);
 		return result;

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/kubernetes/DeployManifest.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/kubernetes/DeployManifest.vsl
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-${rtcParam.name.toLowerCase()}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rtc-${rtcParam.name.toLowerCase()}
+  template:
+    metadata:
+      labels:
+        app: rtc-${rtcParam.name.toLowerCase()}
+    spec:	
+      containers:
+      - name: container-${rtcParam.name.toLowerCase()}
+        image: DOCKER-HUB-LOGIN-NAME/${rtcParam.name.toLowerCase()}:1.0 
+        command:
+          - /usr/local/components/bin/${rtcParam.name}Comp
+        args:
+          - "-o"
+          - "corba.nameservers:10.96.0.100"
+          - "-o"
+          - "manager.components.preactivation:${rtcParam.name}0"
+      nodeSelector:
+        ${rtcParam.name.toLowerCase()}: "true"


### PR DESCRIPTION
## Identify the Bug
- 無し

## Description of the Change

- RTC Builder に Kubernetes環境で使用できる RTC を Pod で配置するファイルを出力する機能を追加
- 出力されたファイルの使い方
    - kubectl apply -f 出力されたファイル

## Verification 
- [X] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  