### PR TITLE
fix : cannot generate docker and kubernetes file

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/build.xml
+++ b/jp.go.aist.rtm.rtcbuilder/build.xml
@@ -92,6 +92,8 @@
 				<include name="cmake/**/**.vsl" />
 				<include name="common/**.vsl" />
 				<include name="cpp/**/**.vsl" />
+				<include name="dockerfile/**.vsl" />
+				<include name="kubernetes/**.vsl" />
 			</fileset>
 		</copy>
 		<mkdir dir="${dist.dir}" />


### PR DESCRIPTION
## Identify the Bug
- 0218d09 をビルドし、パッケージ化したOpenRTPを作成した後に RTC builder から
  テンプレートを出力するときに Dockerfile の出力でエラーが発生した。 
  本修正がない場合もデバッグ環境ではファイルは出力されていた。

## Description of the Change
- build.xml で Dockerfile と kubernetes フォルダ配下をコピー対象に追加 

## Verification 
- [X] Did you succeed the build?  
- [ ] No warnings for the build?  
- [X] Have you passed the unit tests?
   パッケージ化したOpenRTPを使用して、Docker と kubernetes ファイルが
   出力されることを確認した。