### PR TITLE
fix: the dockerfile design to the OpenRTM version 1.2

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/dockerfile/Dockerfile.alpine.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/dockerfile/Dockerfile.alpine.vsl
@@ -16,7 +16,7 @@ RUN cmake -G Ninja -S /RTC -B /RTC/build\
 RUN cmake --build /RTC/build -j --target install/strip
 
 RUN mkdir -p /opt/rtc_lib
-RUN cp -p $(ldd /opt/rtc/components/bin/${rtcParam.name}Comp\
+RUN cp -p $(ldd /opt/rtc/share/openrtm-*/components/c++/Category/${rtcParam.name}/${rtcParam.name}Comp\
  | grep -e libomni -e libRTC | sed -e 's/.*=> //'\
  | sed -e 's/(0x[0-9a-f]*)$//') /opt/rtc_lib
 
@@ -35,7 +35,7 @@ RUN apk add --no-cache\
     && adduser -DH ${username}
 
 COPY --from=rtc /opt/rtc_lib /usr/local/lib
-COPY --from=rtc /opt/rtc/components/bin/${rtcParam.name}Comp /usr/local/components/bin/${rtcParam.name}Comp
+COPY --from=rtc /opt/rtc/share/openrtm-*/components/c++/Category/${rtcParam.name}/${rtcParam.name}Comp /work/${rtcParam.name}Comp
 
 USER ${username}
 WORKDIR /work

--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/dockerfile/Dockerfile.ubuntu.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/dockerfile/Dockerfile.ubuntu.vsl
@@ -19,7 +19,7 @@ RUN cmake --build /RTC/build --target install/strip
 RUN mkdir -p /opt/rtc_lib
 
 RUN cp -p $(LD_LIBRARY_PATH=/opt/openrtm/lib\
- ldd /opt/rtc/components/bin/${rtcParam.name}Comp\
+ ldd /opt/rtc/share/openrtm-*/components/c++/Category/${rtcParam.name}/${rtcParam.name}Comp\
  | grep -e libomni -e libRTC | sed -e 's/.*=> //'\
  | sed -e 's/(0x[0-9a-f]*)$//') /opt/rtc_lib
 
@@ -32,10 +32,10 @@ LABEL  maintainer="${tmpltHelper.convertAuthorDoc(${rtcParam.docCreator})}"
 #end
 
 RUN mkdir -m 777 /work\
-    && adduser --no-create-home --disabled-login ${username}
+    && adduser -q --gecos ""--no-create-home --disabled-login ${username}
 
 COPY --from=rtc /opt/rtc_lib /usr/lib
-COPY --from=rtc /opt/rtc/components/bin/${rtcParam.name}Comp /work/${rtcParam.name}Comp
+COPY --from=rtc /opt/rtc/share/openrtm-*/components/c++/Category/${rtcParam.name}/${rtcParam.name}Comp /work/${rtcParam.name}Comp
 
 USER ${username}
 WORKDIR /work


### PR DESCRIPTION
## Identify the Bug
- OpenRTM v.1.2以降でコンポーネントのインストールパスが変更になっていたため、
  v1.2以降でビルドしたコンポーネントでは docker build に失敗する。 

## Description of the Change
- v1.2以降のパスに合わせてコンポーネントの探索場所を変更 

## Verification 
- [X] Did you succeed the build?  
- [ ] No warnings for the build?  
- [X] Have you passed the unit tests?  