### PR TITLE
fix: an incorrect RT component path

### DIFF
--- a/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/kubernetes/DeployManifest.vsl
+++ b/jp.go.aist.rtm.rtcbuilder/src/jp/go/aist/rtm/rtcbuilder/template/kubernetes/DeployManifest.vsl
@@ -16,7 +16,7 @@ spec:
       - name: container-${rtcParam.name.toLowerCase()}
         image: DOCKER-HUB-LOGIN-NAME/${rtcParam.name.toLowerCase()}:1.0 
         command:
-          - /usr/local/components/bin/${rtcParam.name}Comp
+          - /work/${rtcParam.name}Comp
         args:
           - "-o"
           - "corba.nameservers:10.96.0.100"


### PR DESCRIPTION
- Dockerfile で作成した RTC の格納先を変更したので kubernetes の Manifest を追従する